### PR TITLE
Required python-arango and started building an example of how to use it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# platypi ~ REST platform
+# platypi ~ dynamic data platform
 
 ## Getting Started
 

--- a/restore/README.md
+++ b/restore/README.md
@@ -1,0 +1,5 @@
+# restore ~ REST platform
+
+### Playing Around
+
+Check out the `/scripts` directory to get your feet wet. It's just a playground more than anything.

--- a/restore/requirements.txt
+++ b/restore/requirements.txt
@@ -3,4 +3,6 @@ django-filter==0.13.0
 djangorestframework==3.3.3
 gunicorn==19.4.5
 Markdown==2.6.6
-wheel==0.24.0
+nose==1.3.7
+python-arango==2.2.0
+requests==2.9.1

--- a/restore/scripts/arangotest.py
+++ b/restore/scripts/arangotest.py
@@ -1,0 +1,85 @@
+from arango import Arango
+from arango.exceptions import DatabaseDeleteError
+
+a = Arango(host="platypi.dev", port=8529)
+
+retrodb_name = "retrospective_test"
+iteration_graph_name = "iteration_graph"
+iteration_vertex_collection_name = "iteration_vertex"
+iteration_edge_collection_name = "iteration_edge"
+
+try:
+    a.delete_database(retrodb_name)
+except DatabaseDeleteError:
+    pass
+
+retrodb = a.create_database(retrodb_name)
+iteration_graph = retrodb.create_graph(iteration_graph_name)
+
+iteration_collection = retrodb.create_collection(iteration_vertex_collection_name)
+iteration_vertex_collection = iteration_graph.create_vertex_collection(iteration_vertex_collection_name)
+iteration_edge_collection = retrodb.create_collection(iteration_edge_collection_name, is_edge=True)
+iteration_graph.create_edge_definition(
+    edge_collection=iteration_edge_collection_name,
+    from_vertex_collections=[iteration_vertex_collection_name],
+    to_vertex_collections=[iteration_vertex_collection_name],
+)
+
+iteration_ids = [
+    "4f5c04c7-793a-443b-9035-9514aa301ef6",
+    "6c79a2d7-16cd-4907-88bf-120c89293169",
+    "f4207bf3-3afb-46f4-adae-d573deff8e48"
+]
+
+iterations = [
+    {
+        "_key": iteration_ids[0],
+        "number": 1,
+        "begins": 1459123200,
+        "ends": 1459728000
+    },
+    {
+        "_key": iteration_ids[1],
+        "number": 2,
+        "begins": 1459728000,
+        "ends": 1460332800
+    },
+    {
+        "_key": iteration_ids[2],
+        "number": 3,
+        "begins": 1460332800,
+        "ends": 1460937600
+    }
+]
+
+iteration_edge_ids = [
+    "64514b41-abd7-4cf3-9365-2b628593141b",
+    "80ad8080-2779-4513-8c9c-76cae28eb424"
+]
+
+iteration_edges = [
+    {
+        "_key": iteration_edge_ids[0],
+        "_from": iteration_vertex_collection_name+"/"+iteration_ids[0],
+        "_to": iteration_vertex_collection_name+"/"+iteration_ids[1]
+    },
+    {
+        "_key": iteration_edge_ids[1],
+        "_from": iteration_vertex_collection_name+"/"+iteration_ids[1],
+        "_to": iteration_vertex_collection_name+"/"+iteration_ids[2]
+    }
+]
+
+def build_batch_operation(operation, collection_name, value):
+    return (
+        operation,
+        [collection_name, value],
+        {"wait_for_sync": True}
+    )
+
+iteration_vertex_operations = list(map(lambda iteration: build_batch_operation(iteration_graph.create_vertex, iteration_vertex_collection_name, iteration), iterations))
+
+iteration_edge_operations = list(map(lambda edge: build_batch_operation(iteration_graph.create_edge, iteration_edge_collection_name, edge), iteration_edges))
+
+retrodb.execute_batch(iteration_vertex_operations)
+retrodb.execute_batch(iteration_edge_operations)


### PR DESCRIPTION
For local development (not on docker), you can activate the `/platypi/restore` virtualenv by navigating to that directory and executing the `source` command specified in /platypi/README.md

After activating (or initializing) the virtualenv, you should be able to execute the arangotest.py script to set up a sample graph in ArangoDB. Use Arango's UI (http://your-docker-host-or-ip:8529) to view the newly-created graph in the "retrospective_test" database.
